### PR TITLE
Check the state of the light before switch on / off the light

### DIFF
--- a/custom_components/telerupteur/light.py
+++ b/custom_components/telerupteur/light.py
@@ -124,8 +124,10 @@ class TelerupteurLight(LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn device on."""
-        await self._toggle_light()
+        if self.is_on() is not True:
+            await self._toggle_light()
 
     async def async_turn_off(self, **kwargs):
         """Turn device off."""
-        await self._toggle_light()
+        if self.is_on() is True:
+            await self._toggle_light()


### PR DESCRIPTION
This PR add capability to check state of the light before switch on / off
In the case of the telerupteur, it's important because telerupteur didn't know the state of the light.